### PR TITLE
feat: Partially implements #42, creating "All songs" view

### DIFF
--- a/main/background.ts
+++ b/main/background.ts
@@ -14,6 +14,7 @@ import {
   getPlaylists,
   getRandomLibraryItems,
   getSettings,
+  getSongs,
   initializeData,
   isSongFavorite,
   removeSongFromPlaylist,
@@ -51,7 +52,7 @@ const initializeLibrary = async () => {
       await initializeData(settings.musicFolder);
     }
   } catch (error) {
-    console.error('Error initializing library:', error);
+    console.error("Error initializing library:", error);
   }
 };
 
@@ -113,43 +114,46 @@ const initializeLibrary = async () => {
 
 // @hiaaryan: Initialize Discord RPC
 const client = new Client({
-  clientId: "1243707416588320800"
+  clientId: "1243707416588320800",
 });
 
-ipcMain.on("set-rpc-state", async (_, { details, state, seek, duration, cover }) => {
-  let startTimestamp, endTimestamp;
+ipcMain.on(
+  "set-rpc-state",
+  async (_, { details, state, seek, duration, cover }) => {
+    let startTimestamp, endTimestamp;
 
-  if (duration && seek) {
-    const now = Math.ceil(Date.now());
-    startTimestamp = now - (seek * 1000);
-    endTimestamp = now + ((duration - seek) * 1000);
-  }
-
-  const setActivity = {
-    details,
-    state,
-    largeImageKey: cover,
-    instance: false,
-    type: 2,
-    startTimestamp: startTimestamp,
-    endTimestamp: endTimestamp,
-    buttons: [
-      { label: "Support Project", url: "https://github.com/hiaaryan/wora" },
-    ]
-  };
-
-  if (!client.isConnected) {
-    try {
-      await client.login();
-    } catch (error) {
-      console.error('Error logging into Discord:', error);
+    if (duration && seek) {
+      const now = Math.ceil(Date.now());
+      startTimestamp = now - seek * 1000;
+      endTimestamp = now + (duration - seek) * 1000;
     }
-  }
 
-  if (client.isConnected) {
-    client.user.setActivity(setActivity);
-  }
-});
+    const setActivity = {
+      details,
+      state,
+      largeImageKey: cover,
+      instance: false,
+      type: 2,
+      startTimestamp: startTimestamp,
+      endTimestamp: endTimestamp,
+      buttons: [
+        { label: "Support Project", url: "https://github.com/hiaaryan/wora" },
+      ],
+    };
+
+    if (!client.isConnected) {
+      try {
+        await client.login();
+      } catch (error) {
+        console.error("Error logging into Discord:", error);
+      }
+    }
+
+    if (client.isConnected) {
+      client.user.setActivity(setActivity);
+    }
+  },
+);
 
 // @hiaaryan: Called to Rescan Library
 ipcMain.handle("rescanLibrary", async () => {
@@ -220,6 +224,10 @@ ipcMain.handle("getAlbums", async (_, page) => {
 ipcMain.handle("getAllPlaylists", async () => {
   const playlists = await getPlaylists();
   return playlists;
+});
+
+ipcMain.handle("getSongs", async (_, page) => {
+  return await getSongs(page);
 });
 
 ipcMain.handle("getAlbumWithSongs", async (_, id: number) => {

--- a/main/helpers/db/connectDB.ts
+++ b/main/helpers/db/connectDB.ts
@@ -83,8 +83,26 @@ export const updateSettings = async (data: any) => {
   return true;
 };
 
-export const getSongs = async () => {
-  return await db.select().from(songs).orderBy(songs.name);
+export const getSongs = async (page: number, limit: number = 30) => {
+  return await db
+    .select({
+      id: songs.id,
+      name: songs.name,
+      artist: songs.artist,
+      duration: songs.duration,
+      filePath: songs.filePath,
+      album: {
+        id: albums.id,
+        name: albums.name,
+        artist: albums.artist,
+        cover: albums.cover,
+      },
+    })
+    .from(songs)
+    .orderBy(songs.name)
+    .limit(limit)
+    .offset((page - 1) * limit)
+    .leftJoin(albums, eq(songs.albumId, albums.id));
 };
 
 export const getAlbums = async (page: number, limit: number = 15) => {

--- a/renderer/components/main/navbar.tsx
+++ b/renderer/components/main/navbar.tsx
@@ -37,6 +37,14 @@ type Settings = {
   profilePicture: string;
 };
 
+enum Paths {
+  HOME = "/home",
+  PLAYLISTS = "/playlists",
+  SONGS = "/songs",
+  ALBUMS = "/albums",
+  SETTINGS = "/settings",
+}
+
 const Navbar = () => {
   const router = useRouter();
   const [open, setOpen] = useState(false);
@@ -124,11 +132,11 @@ const Navbar = () => {
   };
 
   useEffect(() => {
-    window.ipc.invoke("getSettings").then((response) => {
+    window?.ipc?.invoke("getSettings").then((response) => {
       setSettings(response);
     });
 
-    window.ipc.on("confirmSettingsUpdate", () => {
+    window?.ipc?.on("confirmSettingsUpdate", () => {
       window.ipc.invoke("getSettings").then((response) => {
         setSettings(response);
       });
@@ -141,21 +149,28 @@ const Navbar = () => {
         <TooltipProvider>
           <Tooltip delayDuration={0}>
             <TooltipTrigger>
-              <Link href="/settings">
+              <Link href={Paths.SETTINGS}>
                 <Avatar className="h-8 w-8">
-                  <AvatarImage src={`${settings && settings.profilePicture ? "wora://" + settings.profilePicture : "/userPicture.png"}`} />
+                  <AvatarImage
+                    src={`${settings?.profilePicture ? "wora://" + settings.profilePicture : "/userPicture.png"}`}
+                  />
                 </Avatar>
               </Link>
             </TooltipTrigger>
             <TooltipContent side="right" sideOffset={25}>
-              <p>{settings && settings.name ? settings.name : "Wora User"}</p>
+              <p>{settings?.name ?? "Wora User"}</p>
             </TooltipContent>
           </Tooltip>
-          <div className="w-[4.5rem] p-8 rounded-2xl wora-border flex flex-col items-center gap-10">
+          <div className="wora-border flex w-[4.5rem] flex-col items-center gap-10 rounded-2xl p-8">
             <Tooltip delayDuration={0}>
               <TooltipTrigger>
-                <Button variant="ghost" asChild>
-                  <Link href="/home">
+                <Button
+                  variant={
+                    router.pathname.includes(Paths.HOME) ? "outline" : "ghost"
+                  }
+                  asChild
+                >
+                  <Link href={Paths.HOME}>
                     <IconInbox stroke={2} className="w-5" />
                   </Link>
                 </Button>
@@ -176,8 +191,15 @@ const Navbar = () => {
             </Tooltip>
             <Tooltip delayDuration={0}>
               <TooltipTrigger>
-                <Button variant="ghost" asChild>
-                  <Link href="/playlists">
+                <Button
+                  variant={
+                    router.pathname.includes(Paths.PLAYLISTS)
+                      ? "outline"
+                      : "ghost"
+                  }
+                  asChild
+                >
+                  <Link href={Paths.PLAYLISTS}>
                     <IconVinyl stroke={2} size={20} />
                   </Link>
                 </Button>
@@ -188,8 +210,13 @@ const Navbar = () => {
             </Tooltip>
             <Tooltip delayDuration={0}>
               <TooltipTrigger>
-                <Button variant="ghost" asChild>
-                  <Link href="/playlists">
+                <Button
+                  variant={
+                    router.pathname.includes(Paths.SONGS) ? "outline" : "ghost"
+                  }
+                  asChild
+                >
+                  <Link href={Paths.SONGS}>
                     <IconList stroke={2} size={20} />
                   </Link>
                 </Button>
@@ -200,8 +227,13 @@ const Navbar = () => {
             </Tooltip>
             <Tooltip delayDuration={0}>
               <TooltipTrigger>
-                <Button variant="ghost" asChild>
-                  <Link href="/albums">
+                <Button
+                  variant={
+                    router.pathname.includes(Paths.ALBUMS) ? "outline" : "ghost"
+                  }
+                  asChild
+                >
+                  <Link href={Paths.ALBUMS}>
                     <IconFocusCentered stroke={2} size={20} />
                   </Link>
                 </Button>
@@ -221,7 +253,6 @@ const Navbar = () => {
               <p className="capitalize">Theme: {theme}</p>
             </TooltipContent>
           </Tooltip>
-
         </TooltipProvider>
       </div>
 
@@ -230,7 +261,8 @@ const Navbar = () => {
           <CommandInput
             placeholder="Search for a song, album or playlist..."
             value={search}
-            onValueChange={setSearch} />
+            onValueChange={setSearch}
+          />
           <CommandList>
             {loading && (
               <div className="flex h-[325px] w-full items-center justify-center">
@@ -247,22 +279,20 @@ const Navbar = () => {
                     className="text-black dark:text-white"
                   >
                     <div className="flex h-full w-full items-center gap-2.5 gradient-mask-r-70">
-                      {(item.type === "Playlist" ||
-                        item.type === "Album") && (
-                          <div className="relative h-12 w-12 overflow-hidden rounded-lg shadow-xl transition duration-300">
-                            <Image
-                              className="object-cover"
-                              src={`wora://${item.cover}`}
-                              alt={item.name}
-                              fill />
-                          </div>
-                        )}
+                      {(item.type === "Playlist" || item.type === "Album") && (
+                        <div className="relative h-12 w-12 overflow-hidden rounded-lg shadow-xl transition duration-300">
+                          <Image
+                            className="object-cover"
+                            src={`wora://${item.cover}`}
+                            alt={item.name}
+                            fill
+                          />
+                        </div>
+                      )}
                       <div>
                         <p className="w-full overflow-hidden text-nowrap text-xs">
                           {item.name}
-                          <span className="ml-1 opacity-50">
-                            ({item.type})
-                          </span>
+                          <span className="ml-1 opacity-50">({item.type})</span>
                         </p>
                         <p className="w-full text-xs opacity-50">
                           {item.type === "Playlist"

--- a/renderer/components/main/player.tsx
+++ b/renderer/components/main/player.tsx
@@ -227,7 +227,7 @@ export const Player = () => {
   }, []);
 
   useEffect(() => {
-    window.ipc.invoke("getAllPlaylists").then((response) => {
+    window?.ipc?.invoke("getAllPlaylists").then((response) => {
       setPlaylists(response);
     });
   }, []);

--- a/renderer/components/ui/actions.tsx
+++ b/renderer/components/ui/actions.tsx
@@ -19,7 +19,7 @@ function Actions() {
   const [isMaximized, setIsMaximized] = useState(false);
 
   useEffect(() => {
-    window.ipc.invoke("getActionsData").then((response) => {
+    window?.ipc?.invoke("getActionsData").then((response) => {
       setData(response);
     });
   }, []);
@@ -45,7 +45,7 @@ function Actions() {
           Wora
         </div>
         <div className="no-drag absolute -right-2 top-0 flex h-full items-center gap-2.5">
-          {data && data.isNotMac && (
+          {data?.isNotMac && (
             <>
               <Button
                 variant="ghost"

--- a/renderer/pages/songs.tsx
+++ b/renderer/pages/songs.tsx
@@ -1,0 +1,93 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  IconPlayerPlay,
+  IconArrowsShuffle2,
+} from "@tabler/icons-react";
+import { Song, usePlayer } from "@/context/playerContext";
+import InfiniteLoadingSongs from "@/components/ui/infinite-loading-songs";
+
+export default function AllSongs() {
+  const [songs, setSongs] = useState<Song[]>([]);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  const { setQueueAndPlay } = usePlayer();
+
+  const loadSongs = useCallback(async () => {
+      if (loading || !hasMore) return;
+      setLoading(true);
+  
+      if (page > 1) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+  
+      try {
+        const newSongs = await window.ipc.invoke("getSongs", page);
+        if (newSongs.length === 0) {
+          setHasMore(false);
+        } else {
+          setSongs((prevSongs) => [...prevSongs, ...newSongs]);
+          setPage((prevPage) => prevPage + 1);
+        }
+      } catch (error) {
+        console.error("Error loading songs:", error);
+      } finally {
+        setLoading(false);
+      }
+    }, [page, loading, hasMore]);
+  
+    useEffect(() => {
+      loadSongs();
+    }, []);
+  
+   
+
+  const playSongs = () => {
+    setQueueAndPlay(songs, 0);
+  };
+
+  const playSongsAndShuffle = () => {
+    setQueueAndPlay(songs, 0, true);
+  };
+
+  return (
+    <>
+      <div className="relative h-96 w-full overflow-hidden rounded-2xl">
+        <div className="absolute bottom-6 left-6">
+          <div className="flex items-end gap-4">
+            <div className="flex flex-col gap-4">
+              <div>
+                <h1 className="text-2xl font-medium">
+                  All Songs
+                </h1>
+              </div>
+              <div className="flex gap-2">
+                <Button onClick={playSongs} className="w-fit">
+                  <IconPlayerPlay
+                    className="fill-black dark:fill-white"
+                    stroke={2}
+                    size={16}
+                  />{" "}
+                  Play
+                </Button>
+                <Button className="w-fit" onClick={playSongsAndShuffle}>
+                  <IconArrowsShuffle2 stroke={2} size={16} /> Shuffle
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="pt-2">
+        <InfiniteLoadingSongs
+          library={songs}
+          hasMore={hasMore}
+          loading={loading}
+          loadMore={loadSongs}
+        />
+      </div>
+    </>
+  );
+}

--- a/renderer/types.ts
+++ b/renderer/types.ts
@@ -1,0 +1,4 @@
+export type Playlist = {
+  id: number;
+  name: string;
+};


### PR DESCRIPTION
This PR implements an "All songs" view, replacing the route in the navbar that currently directs the user to the playlist page.

The view loads the songs paginated with a 30-items page size. It's currently only able to shuffle and queue the songs that are already loaded to the page, so that's why issue #42 is only partially implemented by this PR.

The PR also introduces an "active state" for the navbar buttons to help the user understand in which page they are at.

## Screenshots

![image](https://github.com/user-attachments/assets/befab78f-b367-43d9-a8a4-b8b1811ca7b1)

## Videos

https://github.com/user-attachments/assets/77b5d530-3640-4007-88d4-15a74af7d97c